### PR TITLE
クエリパラメータ有りの場合に動作しないバグを修正

### DIFF
--- a/8209_violation_report.user.js
+++ b/8209_violation_report.user.js
@@ -68,7 +68,7 @@
     GM_addStyle(
       '.violation-report{ display: block; text-align: center; border-radius: 10px; border: 1px solid red; padding: 10px; color: white !important; background: red; }'
     );
-    if (window.location.pathname.match(/\/auction\/(\w+)$/)) {
+    if (/^\/jp\/auction\/(\w+)$/.test(pathname)) {
       var aid = RegExp.$1;
       if (violation[aid] != undefined) {
         GM_addStyle(

--- a/8209_violation_report.user.js
+++ b/8209_violation_report.user.js
@@ -68,7 +68,7 @@
     GM_addStyle(
       '.violation-report{ display: block; text-align: center; border-radius: 10px; border: 1px solid red; padding: 10px; color: white !important; background: red; }'
     );
-    if (window.location.href.match(/\/auction\/(\w+)$/)) {
+    if (window.location.pathname.match(/\/auction\/(\w+)$/)) {
       var aid = RegExp.$1;
       if (violation[aid] != undefined) {
         GM_addStyle(


### PR DESCRIPTION
## バグの内容
クエリパラメータ有りの場合に、通報済みの表示がされないバグがありましたので修正しました。

クエリパラメータ無し（正常動作）
![Screenshot from 2021-09-23 10-24-15](https://user-images.githubusercontent.com/30180897/134694631-fec57e69-f2ca-4223-84a4-aa0990a88b8a.png)

クエリパラメータ有り（動作せず）
![Screenshot from 2021-09-23 10-24-25](https://user-images.githubusercontent.com/30180897/134694636-498a03ab-6033-4142-a7e8-87f38fdb1fc5.png)

## その他
周辺のコードと合わせ、RegExp#testメソッドを使うように変えました。
